### PR TITLE
[BREAKING] Remove "Foundation" from service provider Namespace

### DIFF
--- a/src/EventTrait.php
+++ b/src/EventTrait.php
@@ -48,7 +48,7 @@ trait EventTrait
     {
         $split = explode('\\', (new ReflectionClass($this))->getName());
 
-        return "{$split[0]}\\{$split[2]}\\Foundation\\Providers\\EventServiceProvider";
+        return "{$split[0]}\\{$split[2]}\\Providers\\EventServiceProvider";
     }
 
     public function testEventImplementsTheCorrectInterfaces()

--- a/src/ServiceProviderTrait.php
+++ b/src/ServiceProviderTrait.php
@@ -32,6 +32,6 @@ trait ServiceProviderTrait
         $split = explode('\\', (new ReflectionClass($this))->getName());
         $class = substr(end($split), 0, -4);
 
-        return "{$split[0]}\\{$split[2]}\\Foundation\\Providers\\{$class}";
+        return "{$split[0]}\\{$split[2]}\\Providers\\{$class}";
     }
 }


### PR DESCRIPTION
Cachet code base has been updated to remove the "Foundation" part from the namespace of Event related components. However this has broken a lot of Cachet's tests as this library still expects it. Once this has been merged Cachet can be updated to use new version an get some of the tests working again.

See: https://github.com/CachetHQ/Cachet/pull/4071